### PR TITLE
Implement structured Tokyo address search UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,10 +26,47 @@
         <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 shrink-0" viewBox="0 0 20 20" fill="currentColor">
           <path fill-rule="evenodd" d="M8 4a4 4 0 100 8 4 4 0 000-8zM2 8a6 6 0 1110.89 3.476l4.817 4.817a1 1 0 01-1.414 1.414l-4.816-4.816A6 6 0 012 8z" clip-rule="evenodd"/>
         </svg>
-        <input id="searchInput" class="search-input" placeholder="例）大田区蒲田5-13-1 / 池上三丁目（概算地点）"/>
-        <button id="searchBtn" class="header-item" style="color:#1d4ed8">検索</button>
+        <div class="address-fields">
+          <div class="address-field">
+            <input id="wardInput" class="address-input" list="wardList" placeholder="区を選択" autocomplete="off" />
+            <datalist id="wardList">
+              <option value="千代田区"></option>
+              <option value="中央区"></option>
+              <option value="港区"></option>
+              <option value="新宿区"></option>
+              <option value="文京区"></option>
+              <option value="台東区"></option>
+              <option value="墨田区"></option>
+              <option value="江東区"></option>
+              <option value="品川区"></option>
+              <option value="目黒区"></option>
+              <option value="大田区"></option>
+              <option value="世田谷区"></option>
+              <option value="渋谷区"></option>
+              <option value="中野区"></option>
+              <option value="杉並区"></option>
+              <option value="豊島区"></option>
+              <option value="北区"></option>
+              <option value="荒川区"></option>
+              <option value="板橋区"></option>
+              <option value="練馬区"></option>
+              <option value="足立区"></option>
+              <option value="葛飾区"></option>
+              <option value="江戸川区"></option>
+            </datalist>
+          </div>
+          <div class="address-field address-field--town">
+            <input id="townInput" class="address-input" placeholder="町名（2文字以上）" autocomplete="off" disabled />
+            <div id="townSuggest" class="town-suggest"></div>
+          </div>
+          <div class="address-field address-field--chome">
+            <div id="chomeChips" class="chome-chips">区と町を選択してください</div>
+          </div>
+        </div>
+        <button id="addressSearchBtn" class="address-search-btn" disabled>検索</button>
       </div>
       <div class="btn-container">
+        <button class="header-item" id="optimizeBtn" style="color:#1d4ed8">最適化</button>
         <button class="header-item" id="prevPack">前の10件</button>
         <button class="header-item" id="openPack" style="color:#1d4ed8">Googleマップで開く</button>
         <button class="header-item" id="nextPack">次の10件</button>

--- a/script.js
+++ b/script.js
@@ -890,8 +890,14 @@ function extractEntries(text){
    検索（@geolonia/nja + 区別辞書）
    ========================= */
 
-const searchBtn = document.getElementById('searchBtn');
-const searchInput = document.getElementById('searchInput');
+const PREF_NAME = "東京都";
+
+const wardInput = document.getElementById('wardInput');
+const townInput = document.getElementById('townInput');
+const townSuggest = document.getElementById('townSuggest');
+const chomeChips = document.getElementById('chomeChips');
+const addressSearchBtn = document.getElementById('addressSearchBtn');
+const townField = document.querySelector('.address-field--town');
 
 const TOKYO_WARDS = {
   "千代田区": { code:"13101", slug:"chiyoda",  label:"千代田区" },
@@ -919,9 +925,66 @@ const TOKYO_WARDS = {
   "江戸川区": { code:"13123", slug:"edogawa", label:"江戸川区" }
 };
 const INDEX_CACHE = {}; // ward.code → 辞書JSON
+const TOWN_INDEX_CACHE = new Map(); // ward.code → 町インデックス
+const TOWN_YOMI_CACHE = new Map();  // `${pref}|${ward}|${town}` → ひらがな読み
+let normalizeModulePromise = null;
+
+function kanaToHira(str){
+  if(!str) return '';
+  return str
+    .replace(/[ァ-ン]/g, ch => String.fromCharCode(ch.charCodeAt(0) - 0x60))
+    .replace(/ヵ/g, 'か')
+    .replace(/ヶ/g, 'け');
+}
+
+function preprocessAddressInput(input){
+  if(!input) return '';
+  let text = input.normalize('NFKC');
+  text = text.replace(/[‐–—―ー−]/g, '-');
+  text = text.replace(/[０-９]/g, d => String.fromCharCode(d.charCodeAt(0) - 0xFEE0));
+  text = text.replace(/([一二三四五六七八九十〇零]+)丁目/g, (_, kanji) => {
+    const n = jpNumToInt(kanji);
+    return Number.isFinite(n) ? `${n}丁目` : `${kanji}丁目`;
+  });
+  text = text.replace(/[。、，．・\/／！？!?（）()［］｛｝{}「」『』【】《》〈〉〔〕“”"'…‥；;:]/g, '');
+  text = text.replace(/\s+/g, ' ').trim();
+  return text;
+}
+
+function normalizeTownForMatch(text){
+  return preprocessAddressInput(text || '').replace(/\s+/g, '');
+}
+
+function normalizeYomi(text){
+  const base = preprocessAddressInput(text || '').replace(/\s+/g, '');
+  return kanaToHira(base);
+}
+
+function buildTownQuery(value){
+  const cleaned = preprocessAddressInput(value || '');
+  const collapsed = cleaned.replace(/\s+/g, '');
+  return {
+    raw: value || '',
+    kanji: collapsed,
+    yomi: kanaToHira(collapsed)
+  };
+}
+
+function buildNormalizedAddress(pref, ward, town, chome){
+  const parts = [pref, ward, town].filter(Boolean);
+  if (Number.isInteger(chome)) parts.push(`${chome}丁目`);
+  return parts.join(' ').trim();
+}
+
+async function ensureNormalizer(){
+  if(!normalizeModulePromise){
+    normalizeModulePromise = import("https://esm.sh/@geolonia/normalize-japanese-addresses").then(mod => mod.normalize);
+  }
+  return normalizeModulePromise;
+}
 
 async function loadWardIndex(pref, city){
-  if (pref !== "東京都") throw new Error("東京都のみ対応の最小版です");
+  if (pref !== PREF_NAME) throw new Error("東京都のみ対応の最小版です");
   const ward = TOKYO_WARDS[city];
   if (!ward) throw new Error(`未対応の区です: ${city}`);
   if (INDEX_CACHE[ward.code]) return INDEX_CACHE[ward.code];
@@ -952,10 +1015,87 @@ function townChomeFrom(townName){
   return { town: townName || "", chome: null };
 }
 
+async function getTownReading(pref, ward, town){
+  const key = `${pref}|${ward}|${town}`;
+  if (TOWN_YOMI_CACHE.has(key)) return TOWN_YOMI_CACHE.get(key);
+  try {
+    const normalize = await ensureNormalizer();
+    const result = await normalize(`${pref}${ward}${town}`);
+    const kana = (result.town_kana || '').replace(/\s+/g, '');
+    const hir = normalizeYomi(kana);
+    TOWN_YOMI_CACHE.set(key, hir);
+    return hir;
+  } catch (err) {
+    console.warn('よみ取得に失敗:', pref, ward, town, err);
+    TOWN_YOMI_CACHE.set(key, '');
+    return '';
+  }
+}
+
+async function buildTownIndex(pref, wardName){
+  const ward = TOKYO_WARDS[wardName];
+  if (!ward) return [];
+  if (TOWN_INDEX_CACHE.has(ward.code)) return TOWN_INDEX_CACHE.get(ward.code);
+
+  const dict = await loadWardIndex(pref, wardName);
+  const data = dict?.data || {};
+  const townMap = new Map();
+
+  for (const [key, value] of Object.entries(data)){
+    const [townRaw, chomeRaw] = key.split('|');
+    if (!townRaw) continue;
+    const townName = townRaw.trim();
+    if (!townName) continue;
+    let entry = townMap.get(townName);
+    if (!entry){
+      entry = {
+        town: townName,
+        chomeSet: new Set(),
+        points: new Map(),
+        defaultPoint: null
+      };
+      townMap.set(townName, entry);
+    }
+    const chomeKey = (chomeRaw && chomeRaw !== '-') ? chomeRaw : '-';
+    entry.points.set(chomeKey, value);
+    if (chomeKey === '-') entry.defaultPoint = value;
+    else entry.chomeSet.add(chomeKey);
+  }
+
+  const entries = Array.from(townMap.values());
+  const results = await Promise.all(entries.map(async entry => {
+    const yomi = await getTownReading(pref, wardName, entry.town);
+    const chomes = Array.from(entry.chomeSet).map(n => parseInt(n, 10)).filter(n => Number.isInteger(n)).sort((a,b)=>a-b);
+    let defaultPoint = entry.defaultPoint;
+    if (!defaultPoint){
+      const coords = Array.from(entry.points.values());
+      if (coords.length){
+        const lat = coords.reduce((sum,p)=>sum + p.lat,0) / coords.length;
+        const lng = coords.reduce((sum,p)=>sum + p.lng,0) / coords.length;
+        defaultPoint = { lat, lng, level: coords[0]?.level || 'average' };
+      }
+    }
+    return {
+      town: entry.town,
+      townNormalized: normalizeTownForMatch(entry.town),
+      yomiDisplay: yomi,
+      yomiNormalized: normalizeYomi(yomi),
+      chomes,
+      points: Object.fromEntries(entry.points),
+      defaultPoint
+    };
+  }));
+
+  results.sort((a,b)=>a.town.localeCompare(b.town,'ja'));
+  TOWN_INDEX_CACHE.set(ward.code, results);
+  return results;
+}
+
 // @geolonia/normalize-japanese-addresses で代表点に寄せる
 async function geocodeTokyo23(address){
-  const { normalize } = await import("https://esm.sh/@geolonia/normalize-japanese-addresses");
-  const nja = await normalize(address);
+  const normalize = await ensureNormalizer();
+  const cleaned = preprocessAddressInput(address);
+  const nja = await normalize(cleaned);
   const pref = nja.pref || "";
   const city = nja.city || nja.county || "";
 
@@ -990,72 +1130,269 @@ function setSearchPin(lat,lng,label){
   return m;
 }
 
-// 検索バーに × を挿入（最適化ボタンと重ならないように動的に右余白を算出）
-(function initSearchClear(){
-  const bar   = document.querySelector('.search-bar');
-  const input = document.getElementById('searchInput');
-  const opt   = document.getElementById('searchBtn'); // ← 最適化ボタンに転用済み
-  if (!bar || !input) return;
+let currentWardInfo = null;
+let currentTownIndex = [];
+let selectedTownEntry = null;
+let selectedChome = null;
+let townSuggestTimer = null;
+let wardLoadToken = 0;
 
-  let clearBtn = bar.querySelector('.search-clear');
-  if(!clearBtn){
-    clearBtn = document.createElement('button');
-    clearBtn.className = 'search-clear';
-    clearBtn.type = 'button';
-    clearBtn.setAttribute('aria-label','クリア');
-    clearBtn.textContent = '×';
-    bar.appendChild(clearBtn);
+const TOWN_SUGGEST_DEBOUNCE = 120;
+const TOWN_SUGGEST_MAX = 20;
+
+function updateSearchButtonState(){
+  const ready = Boolean(currentWardInfo && selectedTownEntry);
+  if (addressSearchBtn) addressSearchBtn.disabled = !ready;
+}
+
+function renderChomeChips(entry, placeholder = '区と町を選択してください'){
+  if (!chomeChips) return;
+  chomeChips.innerHTML = '';
+  if (!entry){
+    chomeChips.classList.add('empty');
+    chomeChips.textContent = placeholder;
+    return;
   }
-
-  // 最適化ボタンの実寸から、×の right を決める
-  function placeClear(){
-    // ボタンが無ければ従来の 2.5rem
-    let right = 40; // px
-    if (opt) {
-      const w = Math.ceil(opt.getBoundingClientRect().width); // 実幅
-      right = w - 3; // ボタン幅 + ちょい間隔
-    }
-    clearBtn.style.right = right + 'px';
+  const chomes = entry.chomes || [];
+  if (!chomes.length){
+    chomeChips.classList.add('empty');
+    chomeChips.textContent = '丁目情報なし（未選択で検索可）';
+    return;
   }
-
-  const toggle = ()=> {
-    const v = (input.value || '').trim();
-    clearBtn.style.display = v ? 'inline-flex' : 'none';
-    placeClear();
-  };
-
-  input.addEventListener('input', toggle);
-  input.addEventListener('keydown', e => {
-    if(e.key==='Escape'){ input.value=''; input.dispatchEvent(new Event('input')); input.focus(); }
+  chomeChips.classList.remove('empty');
+  const frag = document.createDocumentFragment();
+  chomes.forEach(num => {
+    const chip = document.createElement('button');
+    chip.type = 'button';
+    chip.className = 'chome-chip';
+    chip.dataset.value = String(num);
+    chip.textContent = String(num);
+    chip.addEventListener('click', () => {
+      const value = Number(chip.dataset.value);
+      selectedChome = (selectedChome === value) ? null : value;
+      Array.from(chomeChips.querySelectorAll('.chome-chip')).forEach(btn => {
+        const v = Number(btn.dataset.value);
+        btn.classList.toggle('is-active', selectedChome === v);
+      });
+      updateSearchButtonState();
+    });
+    frag.appendChild(chip);
   });
-  clearBtn.addEventListener('click', ()=>{ input.value=''; input.dispatchEvent(new Event('input')); input.focus(); });
+  const note = document.createElement('span');
+  note.className = 'chome-note';
+  note.textContent = '※ 未選択でも検索できます';
+  frag.appendChild(note);
+  chomeChips.appendChild(frag);
+  Array.from(chomeChips.querySelectorAll('.chome-chip')).forEach(btn => {
+    const v = Number(btn.dataset.value);
+    btn.classList.toggle('is-active', selectedChome === v);
+  });
+}
 
-  // リサイズやフォント計測後にも位置を調整
-  window.addEventListener('resize', placeClear);
-  setTimeout(placeClear, 0);
-  toggle();
-})();
+function hideTownSuggestions(){
+  if (!townSuggest) return;
+  townSuggest.innerHTML = '';
+  townSuggest.classList.remove('is-open');
+}
 
-// 検索ボタン/Enter
-async function onSearch(){
-  const q = (searchInput.value || '').trim();
-  if(!q) return;
-  try{
-    const r = await geocodeTokyo23(q);
-    if(!r.ok){ alert(r.reason || "見つかりませんでした"); return; }
-    setSearchPin(r.lat, r.lng, `${r.label || "検索地点"}（概算・代表点）`);
-  }catch(e){
-    console.error(e);
-    alert(e.message || "検索に失敗しました");
+function showTownSuggestions(entries){
+  if (!townSuggest) return;
+  townSuggest.innerHTML = '';
+  if (!entries.length){
+    hideTownSuggestions();
+    return;
+  }
+  const frag = document.createDocumentFragment();
+  entries.slice(0, TOWN_SUGGEST_MAX).forEach(entry => {
+    const btn = document.createElement('button');
+    btn.type = 'button';
+    btn.innerHTML = `<span>${entry.town}</span>`;
+    btn.className = 'town-suggest-item';
+    if (entry.yomiDisplay){
+      const span = document.createElement('span');
+      span.className = 'suggest-yomi';
+      span.textContent = entry.yomiDisplay;
+      btn.appendChild(span);
+    }
+    btn.addEventListener('click', () => {
+      selectedTownEntry = entry;
+      selectedChome = null;
+      if (townInput) {
+        townInput.value = entry.town;
+        townInput.setAttribute('data-selected-town', entry.town);
+      }
+      renderChomeChips(entry, '丁目情報なし（未選択で検索可）');
+      hideTownSuggestions();
+      updateSearchButtonState();
+    });
+    frag.appendChild(btn);
+  });
+  townSuggest.appendChild(frag);
+  townSuggest.classList.add('is-open');
+}
+
+function filterTownSuggestions(query){
+  if (!query) return [];
+  const targetLen = Math.max(query.kanji.length, query.yomi.length);
+  if (targetLen < 2) return [];
+  const hits = [];
+  for (const entry of currentTownIndex){
+    const yomiMatch = query.yomi.length >= 2 && entry.yomiNormalized && entry.yomiNormalized.startsWith(query.yomi);
+    const kanjiMatch = query.kanji.length >= 2 && entry.townNormalized.startsWith(query.kanji);
+    if (!yomiMatch && !kanjiMatch) continue;
+    hits.push({ entry, weight: yomiMatch ? 0 : 1 });
+  }
+  hits.sort((a,b)=>a.weight - b.weight || a.entry.town.length - b.entry.town.length || a.entry.town.localeCompare(b.entry.town,'ja'));
+  return hits.map(h => h.entry).slice(0, TOWN_SUGGEST_MAX);
+}
+
+function resolveWardInfo(raw){
+  const cleaned = preprocessAddressInput(raw || '').replace(/\s+/g, '');
+  if (!cleaned) return null;
+  let name = cleaned.replace(new RegExp(`^${PREF_NAME}`), '');
+  name = name.replace(/区+$/, '区');
+  if (!name.endsWith('区')) name += '区';
+  return TOKYO_WARDS[name] || null;
+}
+
+async function handleWardChange(){
+  const info = resolveWardInfo(wardInput?.value || '');
+  if (!info){
+    currentWardInfo = null;
+    wardLoadToken++;
+    currentTownIndex = [];
+    selectedTownEntry = null;
+    selectedChome = null;
+    if (townInput){
+      townInput.value = '';
+      townInput.disabled = true;
+      townInput.removeAttribute('data-selected-town');
+      townInput.placeholder = '町名（2文字以上）';
+    }
+    hideTownSuggestions();
+    renderChomeChips(null, '区と町を選択してください');
+    updateSearchButtonState();
+    return;
+  }
+
+  if (wardInput) wardInput.value = info.label;
+  currentWardInfo = info;
+  const token = ++wardLoadToken;
+  currentTownIndex = [];
+  selectedTownEntry = null;
+  selectedChome = null;
+  hideTownSuggestions();
+  renderChomeChips(null, '町の辞書を読み込み中…');
+  updateSearchButtonState();
+  if (townInput){
+    townInput.value = '';
+    townInput.disabled = true;
+    townInput.placeholder = '町名（読込中…）';
+    townInput.removeAttribute('data-selected-town');
+  }
+
+  try {
+    const towns = await buildTownIndex(PREF_NAME, info.label);
+    if (token !== wardLoadToken) return;
+    currentTownIndex = towns;
+    if (townInput){
+      townInput.disabled = false;
+      townInput.placeholder = '町名（2文字以上）';
+    }
+    renderChomeChips(null, '町を候補から選択してください');
+  } catch (err){
+    if (token !== wardLoadToken) return;
+    console.error(err);
+    alert(err.message || '町の辞書を読み込めませんでした');
+    if (townInput){
+      townInput.disabled = true;
+      townInput.placeholder = '町名（読み込み失敗）';
+    }
+    renderChomeChips(null, '辞書の読み込みに失敗しました');
+  } finally {
+    if (token === wardLoadToken) updateSearchButtonState();
   }
 }
-searchBtn?.addEventListener("click", onSearch);
-searchInput?.addEventListener("keydown", e => { if(e.key==="Enter") onSearch(); });
+
+function handleTownInput(){
+  if (!townInput) return;
+  const value = townInput.value || '';
+  if (townInput.dataset.selectedTown !== value){
+    selectedTownEntry = null;
+    selectedChome = null;
+    townInput.removeAttribute('data-selected-town');
+    renderChomeChips(null, '候補から町を選択してください');
+    updateSearchButtonState();
+  }
+
+  if (townSuggestTimer) clearTimeout(townSuggestTimer);
+  const query = buildTownQuery(value);
+  if (Math.max(query.kanji.length, query.yomi.length) < 2){
+    hideTownSuggestions();
+    return;
+  }
+  townSuggestTimer = setTimeout(() => {
+    const suggestions = filterTownSuggestions(query);
+    if (suggestions.length) showTownSuggestions(suggestions);
+    else hideTownSuggestions();
+  }, TOWN_SUGGEST_DEBOUNCE);
+}
+
+function handleTownKeydown(e){
+  if (e.key === 'Enter'){
+    if (townSuggest && townSuggest.classList.contains('is-open')){
+      const first = townSuggest.querySelector('button');
+      if (first){
+        e.preventDefault();
+        first.click();
+      }
+    }
+  } else if (e.key === 'Escape'){
+    hideTownSuggestions();
+  }
+}
+
+async function confirmSelectedAddress(){
+  if (!currentWardInfo || !selectedTownEntry) return;
+  const chomeKey = Number.isInteger(selectedChome) ? String(selectedChome) : '-';
+  const point = selectedTownEntry.points[chomeKey] || selectedTownEntry.defaultPoint;
+  if (!point){
+    alert('辞書に該当する地点が見つかりませんでした');
+    return;
+  }
+  const normalized = buildNormalizedAddress(PREF_NAME, currentWardInfo.label, selectedTownEntry.town, selectedChome);
+  setSearchPin(point.lat, point.lng, normalized);
+}
+
+if (wardInput){
+  wardInput.addEventListener('change', handleWardChange);
+  wardInput.addEventListener('input', () => {
+    if (!wardInput.value.trim()) handleWardChange();
+  });
+  wardInput.addEventListener('blur', handleWardChange);
+}
+
+if (townInput){
+  townInput.addEventListener('input', handleTownInput);
+  townInput.addEventListener('focus', () => {
+    if (townInput.value && townInput.value.length >= 2) handleTownInput();
+  });
+  townInput.addEventListener('keydown', handleTownKeydown);
+}
+
+if (townField){
+  document.addEventListener('click', (event) => {
+    if (!townField.contains(event.target)) hideTownSuggestions();
+  });
+}
+
+addressSearchBtn?.addEventListener('click', confirmSelectedAddress);
+renderChomeChips(null, '区と町を選択してください');
+updateSearchButtonState();
 
 // 置き換え（最適化ボタン転用部）
-const optimizeBtn = document.getElementById('searchBtn');
+const optimizeBtn = document.getElementById('optimizeBtn');
 if (optimizeBtn) {
-  optimizeBtn.textContent = '最適化';
   optimizeBtn.onclick = () => { if (typeof isFilterOn==='function' && isFilterOn()) return; optimizeRoute(); };
 }
 
@@ -1099,7 +1436,7 @@ function syncFilterButtons() {
 
   // ついでに、フィルターONの間は一部操作を視覚的にも無効化
   const disable = isFilterOn();
-  const idsToToggle = ['openPack','prevPack','nextPack','searchBtn']; // パック系のみ見た目無効化（安全）
+  const idsToToggle = ['openPack','prevPack','nextPack','optimizeBtn','addressSearchBtn']; // パック系のみ見た目無効化（安全）
   idsToToggle.forEach(id => {
     const el = document.getElementById(id);
     if (!el) return;

--- a/style.css
+++ b/style.css
@@ -26,8 +26,136 @@ body { margin:0; padding:0; overflow:hidden; font-family:'Inter',system-ui,-appl
 
 /* 画面上部のUI */
 .header{ position:absolute; top:1rem; left:1rem; right:1rem; z-index:1000; display:flex; flex-direction:column; gap:.5rem; align-items:center; }
-.search-bar{ width:100%; background:#fff; border-radius:2rem; padding:.0rem; box-shadow:0 2px 4px rgba(0,0,0,.2); display:flex; align-items:center; gap:.5rem; color:#777; }
-.search-input{ flex:1; border:none; outline:none; font-size:1.2rem; color:#333; padding:.5rem .75rem; }
+.search-bar{
+  width:100%;
+  background:#fff;
+  border-radius:2rem;
+  padding:0 .75rem;
+  box-shadow:0 2px 4px rgba(0,0,0,.2);
+  display:flex;
+  align-items:center;
+  gap:.75rem;
+  color:#777;
+  min-height:3rem;
+  position:relative;
+}
+.address-fields{
+  display:flex;
+  align-items:center;
+  gap:.5rem;
+  flex:1 1 auto;
+  min-width:0;
+}
+.address-field{
+  position:relative;
+  flex:1 1 0;
+  min-width:0;
+}
+.address-field--chome{ flex:1.2 1 0; }
+.address-input{
+  width:100%;
+  border:none;
+  outline:none;
+  font-size:1rem;
+  color:#333;
+  padding:.6rem .45rem;
+  background:transparent;
+}
+.address-input:disabled{ color:#9ca3af; cursor:not-allowed; }
+.address-input::placeholder{ color:#a1a1aa; }
+.town-suggest{
+  position:absolute;
+  top:100%;
+  left:0;
+  right:0;
+  margin-top:.25rem;
+  background:#fff;
+  border-radius:.75rem;
+  box-shadow:0 10px 24px rgba(0,0,0,.18);
+  display:none;
+  z-index:1200;
+  max-height:18rem;
+  overflow-y:auto;
+}
+.town-suggest.is-open{ display:block; }
+.town-suggest button{
+  width:100%;
+  display:flex;
+  justify-content:space-between;
+  align-items:center;
+  gap:.5rem;
+  padding:.45rem .75rem;
+  border:none;
+  background:#fff;
+  cursor:pointer;
+  font-size:.95rem;
+  color:#111827;
+}
+.town-suggest button span:first-child{
+  flex:1 1 auto;
+  text-align:left;
+  overflow:hidden;
+  text-overflow:ellipsis;
+  white-space:nowrap;
+}
+.town-suggest button:hover,
+.town-suggest button:focus{ background:#eef2ff; outline:none; }
+.town-suggest .suggest-yomi{ font-size:.75rem; color:#6b7280; margin-left:auto; }
+.chome-chips{
+  display:flex;
+  align-items:center;
+  flex-wrap:wrap;
+  gap:.4rem;
+  min-height:2.5rem;
+  padding:0 .25rem;
+  font-size:.85rem;
+  color:#6b7280;
+}
+.chome-chips.empty{ color:#9ca3af; }
+.chome-chip{
+  border:1px solid #d1d5db;
+  border-radius:9999px;
+  padding:.25rem .65rem;
+  background:#fff;
+  color:#111827;
+  cursor:pointer;
+  font-size:.85rem;
+  transition:background .15s ease, color .15s ease;
+}
+.chome-chip:hover{ background:#eef2ff; }
+.chome-chip.is-active{
+  background:#2563eb;
+  color:#fff;
+  border-color:#2563eb;
+}
+.chome-note{ font-size:.72rem; color:#9ca3af; }
+.chome-placeholder{ color:#9ca3af; }
+.address-search-btn{
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
+  height:2.5rem;
+  padding:0 1.1rem;
+  border-radius:9999px;
+  background:#2563eb;
+  color:#fff;
+  font-weight:600;
+  font-size:.95rem;
+  border:none;
+  cursor:pointer;
+  flex-shrink:0;
+  transition:background .2s ease;
+}
+.address-search-btn:disabled{
+  background:#c7d2fe;
+  cursor:not-allowed;
+  opacity:.85;
+}
+.address-search-btn:not(:disabled):hover{ background:#1d4ed8; }
+.address-search-btn.is-disabled{
+  pointer-events:none;
+  opacity:.65;
+}
 .btn-container{ display:flex; align-items:center; gap:.5rem; width:100%; overflow-x:auto; white-space:nowrap; -webkit-overflow-scrolling:touch; }
 .header-item{ display:inline-flex; align-items:center; justify-content:center; height:2rem; padding:0 1rem; border-radius:9999px; background:#fff; color:#333; font-size:.875rem; font-weight:500; box-shadow:0 1px 3px rgba(0,0,0,.1); cursor:pointer; flex-shrink:0; }
 
@@ -124,20 +252,6 @@ body { margin:0; padding:0; overflow:hidden; font-family:'Inter',system-ui,-appl
   box-sizing: border-box; 
 }
 
-/* 検索バー内のベース高さを決める（バー自体の大きさは据え置き） */
-.search-bar {
-  min-height: 3rem;            /* 既存の見た目に近い高さのまま */
-  padding: 0 .5rem;            /* 左右の余白だけ少し持たせる（0でもOK） */
-  align-items: center;         /* 垂直センター揃え（再確認） */
-}
-
-/* 入力とボタン／アイコンを同じ高さ・縦中央に */
-.search-input {
-  height: 2.5rem;              /* 中の要素を揃える基準 */
-  line-height: 2.5rem;         /* テキストの縦位置を中央に */
-  padding: 0 .75rem;           /* 既存の余白を維持 */
-}
-
 /* 虫眼鏡アイコンにクラスが無い場合でも効くように、汎用的に対応 */
 .search-bar svg,
 .search-bar i,
@@ -148,15 +262,6 @@ body { margin:0; padding:0; overflow:hidden; font-family:'Inter',system-ui,-appl
   justify-content: center;
   height: 2.5rem;              /* 入力と同じ高さに */
   line-height: 1;              /* 余計な縦ズレを避ける */
-}
-
-/* ボタンの見た目を微調整（形は据え置き） */
-.search-bar button {
-  padding: 0 .9rem;
-  border: none;                /* 既にボタンに枠があれば外す */
-  background: transparent;     /* 既存デザインを尊重、必要なら #fff などに */
-  border-radius: 9999px;
-  cursor: pointer;
 }
 
 /* アイコンの大きさを安定させる（Material IconsやSVGの場合） */
@@ -172,17 +277,6 @@ body { margin:0; padding:0; overflow:hidden; font-family:'Inter',system-ui,-appl
 .leaflet-bottom.leaflet-right .leaflet-control-zoom {
   margin-bottom: 6.5rem !important;
 }
-
-/* 検索バーのクリア× */
-.search-bar { position: relative; }
-.search-clear {
-  position: absolute; right: 2.5rem; top: 50%; transform: translateY(-50%);
-  width: 1.75rem; height: 1.75rem; border-radius: 9999px;
-  display: none; align-items: center; justify-content: center;
-  background: #f3f4f6; border: 1px solid #e5e7eb; cursor: pointer;
-  font-weight: 700; color: #666; line-height: 1;
-}
-.search-clear:hover { background:#eee; }
 
 .lock-btn{
   border:1px solid #e5e7eb; background:#fff; color:#444;


### PR DESCRIPTION
## Summary
- replace the free-text search bar with ward/town/chome controls that lock users to Tokyo 23 ward dictionaries
- add styles for the multi-field address input, autocomplete list, and 丁目 chips to match the new UX
- update the address search logic to normalize text, cache ward dictionaries, surface kana readings, and confirm selections before dropping the map pin

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d52888de108324964dcf95ab167f78